### PR TITLE
[daemon] Update display on events when locked

### DIFF
--- a/daemon/src/toholed-dbus.cpp
+++ b/daemon/src/toholed-dbus.cpp
@@ -289,7 +289,9 @@ void Toholed::updateDisplay(bool timeUpdateOverride, int blinks)
         }
 
         emit displayUpdated();
-    } else if (lockDrawingMode && oledInitDone) {
+    }
+    else if (lockDrawingMode && oledInitDone)
+    {
         updateOled(screenBuffer);
     }
 

--- a/daemon/src/toholed-dbus.cpp
+++ b/daemon/src/toholed-dbus.cpp
@@ -289,6 +289,8 @@ void Toholed::updateDisplay(bool timeUpdateOverride, int blinks)
         }
 
         emit displayUpdated();
+    } else if (lockDrawingMode && oledInitDone) {
+        updateOled(screenBuffer);
     }
 
 }


### PR DESCRIPTION
The external program may have updated display contents while the OLED display
has been off, so update the contents on the display when it is turned off to
avoid having old contents.
